### PR TITLE
Fix turning on lights using Siri

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ class Lightbulb {
           return
         }
 
-        if (value === 1) {
+        if (value) {
           client.turnOn(this.deviceId)
         } else {
           client.turnOff(this.deviceId)


### PR DESCRIPTION
It appears that a state value sent when turning on lights using Siri is sometimes a bool value instead of a number. This PR works around that.